### PR TITLE
fix: correctly apply offset and rotation to Polygon aperture macros

### DIFF
--- a/src/gerbonara/aperture_macros/primitive.py
+++ b/src/gerbonara/aperture_macros/primitive.py
@@ -217,7 +217,7 @@ class Polygon(Primitive):
             rotation += deg_to_rad(calc.rotation)
             x, y = rotate_point(calc.x, calc.y, -rotation, 0, 0)
             x, y = x+offset[0], y+offset[1]
-            return [ gp.ArcPoly.from_regular_polygon(calc.x, calc.y, calc.diameter/2, calc.n_vertices, rotation,
+            return [ gp.ArcPoly.from_regular_polygon(x, y, calc.diameter/2, calc.n_vertices, rotation,
                         polarity_dark=(bool(calc.exposure) == polarity_dark)) ]
 
     def dilated(self, offset, unit):


### PR DESCRIPTION
Bug in the to_graphic_primitives method for polygonal apertures. Currently, the local coordinates (calc.x, calc.y) are used to generate the ArcPoly instead of the transformed and offset coordinates (x, y).

This results in polygonal pads (like octagons) being rendered at the origin $(0, 0)$ or local offsets rather than their actual position on the PCB layout, making them appear "missing" or misaligned in SVG exports.